### PR TITLE
feature: Allow only one auth type in http file

### DIFF
--- a/chk/modules/http/validation_rules.py
+++ b/chk/modules/http/validation_rules.py
@@ -54,11 +54,13 @@ request_schema = {  # cerberus validation rules
                 'required': False,
                 'empty': False,
                 'type': 'dict',
+                'excludes': 'auth[bearer]',
             },
             'auth[bearer]': {
                 'required': False,
                 'empty': False,
                 'type': 'dict',
+                'excludes': 'auth[basic]',
             },
             'body[none]': {
                 'required': False,

--- a/tests/modules/http/http_entities_test.py
+++ b/tests/modules/http/http_entities_test.py
@@ -150,6 +150,14 @@ class TestHttpV072:
         with pytest.raises(SystemExit):
             assert ver.validate_config(doc) is True
 
+    def test_validate_get_with_ba_and_be_sametime_expect_fail(self):
+        """when basic and bearer auth given same time"""
+        doc = ChkFileLoader.to_dict(tests.RES_DIR + 'fail_cases/GET-WithBasicAuth-AndBearer.chk')
+        ver = HttpV072()
+
+        with pytest.raises(SystemExit):
+            assert ver.validate_config(doc) is True
+
     def test_validate_get_with_be_expect_pass(self):
         """when version string not given"""
         doc = ChkFileLoader.to_dict(tests.RES_DIR + 'pass_cases/GET-WithBearerAuth.chk')

--- a/tests/resources/storage/sample_config/fail_cases/GET-WithBasicAuth-AndBearer.chk
+++ b/tests/resources/storage/sample_config/fail_cases/GET-WithBasicAuth-AndBearer.chk
@@ -1,0 +1,20 @@
+---
+version: 'default:http:0.7.2'
+request:
+  url: https://hookb.in/2q9eQGeepPidzq88Rxek
+  method: GET
+
+  url_params:
+      foo: bar
+      two: 2
+
+  headers:
+    User-Agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36'
+    Accept-Encoding: gzip, deflate
+
+  auth[basic]:
+    username: Some_USER
+    password: "Some-P@$$W03D"
+
+  auth[bearer]:
+    token: "Some_USER+token=56456"


### PR DESCRIPTION
- validate that auth[basic] and auth[bearer] can not exist on same file

Closes: #44